### PR TITLE
Make file/folder deletion cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "build": "rm -rf ./public/js && webpack --mode=production",
-    "watch": "rm -rf ./public/js && IS_SENTRY_ENABLED=false webpack --mode=development -w",
+    "build": "rimraf ./public/js && webpack --mode=production",
+    "watch": "rimraf ./public/js && IS_SENTRY_ENABLED=false webpack --mode=development -w",
     "test": "jest",
     "eslint": "eslint './{src,test}/**/*.{ts,tsx}'",
     "eslint:fix": "eslint --fix './{src,test}/**/*.{ts,tsx}'",
@@ -11,7 +11,7 @@
     "stylelint:fix": "stylelint --fix './src/**/*.pcss'",
     "lint": "run-p eslint prettier stylelint",
     "lint:fix": "run-p eslint:fix prettier:fix stylelint:fix",
-    "release": "rm -f out.zip && yarn install && yarn run build && zip -r out.zip public",
+    "release": "rimraf out.zip && yarn install && yarn run build && zip -r out.zip public",
     "check-ngword": "if grep -rE \"console\\.(log|dir)|FIXME\" ./src ./test; then exit 1; else echo \"All good\"; fi",
     "check-all": "run-p test lint check-ngword"
   },
@@ -51,6 +51,7 @@
     "postcss-nested": "^6.0.0",
     "postcss-preset-env": "^7.8.3",
     "prettier": "^2.8.1",
+    "rimraf": "^4.1.2",
     "style-loader": "^3.3.1",
     "stylelint": "^14.16.1",
     "stylelint-config-prettier": "^9.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5970,6 +5970,11 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-4.1.2.tgz#20dfbc98083bdfaa28b01183162885ef213dbf7c"
+  integrity sha512-BlIbgFryTbw3Dz6hyoWFhKk+unCcHMSkZGrTFVAx2WmttdBSonsdtRlwiuTbDqTKr+UlXIUqJVS4QT5tUzGENQ==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"


### PR DESCRIPTION
The `rm` command doesn't work on Windows.

Replace `rm` with the popular, cross-platform [`rimraf`](https://www.npmjs.com/package/rimraf) module, to ensure `package.json` scripts like `build`, `watch`, and `release` run successfully across the major device platforms that are likely to be used for development by contributors (Windows, macOS, and Linux).